### PR TITLE
Only show command when in RPGLE editor context

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 			"editor/context": [
 				{
 					"command": "vscode-rpgfree.rpgleFree",
-					"group": "1_rpgle"
+					"group": "1_rpgle",
+					"when": "editorLangId == rpgle"
 				}
 			]
 		}


### PR DESCRIPTION
Previously it would show up for all languages, but now only shows up when using .rpgle or .sqlrpgle - or whatever you have it configured with.