### PR TITLE
Update RpgleFree.js

### DIFF
--- a/src/RpgleFree.js
+++ b/src/RpgleFree.js
@@ -347,7 +347,7 @@ module.exports = class RpgleFree {
         }
   
       } else {
-        if (wasSub) {
+        if (wasSub && line[7] !== `*`) {
           endBlock(this.lines,this.indent);
         }
       }


### PR DESCRIPTION
Don't trigger endblock when line is a comment. Related to BrianGarland/vscode-rpgfree#45

Tested with different types of line after the end of the datastructure (D/C/blank)

Two minor caveats:
1. If an unrelated comment is on the line immediately after the DS then it will be pulled within the end-ds tag.

2. Issue 32 "Converted RPG Fixed DS code does not include End-Ds; if last DS in conversion set" still applies. So if you convert the code this fix will remove the spurious end-ds tags within the datastructure, but if you don't select a subsequent D/C/blank line then no end-ds will be added.